### PR TITLE
Fix: Camera Player start to the player

### DIFF
--- a/Assets/App/Scripts/Camera/PlayerCameraController.cs
+++ b/Assets/App/Scripts/Camera/PlayerCameraController.cs
@@ -13,8 +13,13 @@ public class PlayerCameraController : MonoBehaviour
     
     [Header("Output")]
     [SerializeField] private RSO_PlayerCameraController m_PlayerCamera;
+    
+    private void OnEnable()
+    {
+        m_PlayerCamera.Set(this);
+        m_CinemachineCamera.ForceCameraPosition(m_PlayerController.Get().GetTargetPosition(),m_CinemachineCamera.transform.rotation);
+    }
 
-    private void OnEnable() => m_PlayerCamera.Set(this);
     private void OnDisable() => m_PlayerCamera.Set(null);
 
     public Camera GetCamera() => m_Camera;


### PR DESCRIPTION
When you launch a scene if the camera player is not at the same place of the player, the camera suppose to start directly on the player